### PR TITLE
Fix readline history sharing between cmd.Cmd and HistoryManager

### DIFF
--- a/dql/cli.py
+++ b/dql/cli.py
@@ -44,6 +44,7 @@ from .help import (
     SELECT,
     UPDATE,
 )
+from . import readline_compat  # noqa: F401  # patch sys.modules['readline'] early
 from .history import HistoryManager
 from .monitor import Monitor
 from .output import (
@@ -92,26 +93,6 @@ DEFAULT_CONFIG = {
     "lossy_json_float": True,
     "_throttle": {},
 }
-
-
-# try:
-#     import gnureadline as readline
-#     import rlcompleter
-# except ImportError:
-#     # Windows doesn't have readline, so gracefully ignore.
-#     pass
-# else:
-#     # Mac OS X readline compatibility from http://stackoverflow.com/a/7116997
-#     if "libedit" in str(readline.__doc__):
-#         readline.parse_and_bind("bind ^I rl_complete")
-#     else:
-#         readline.parse_and_bind("tab: complete")
-#     # Tab-complete names with a '-' in them
-#     delims = set(readline.get_completer_delims())
-#     if "-" in delims:
-#         delims.remove("-")
-#         readline.set_completer_delims("".join(delims))
-
 
 # Installing the rich traceback handler for un-handled errors.
 install()
@@ -273,24 +254,6 @@ class DQLClient(cmd.Cmd):
     ) -> None:
         """Set up the repl for execution."""
         self.history_manager.try_to_load_history()
-        try:
-            import gnureadline as readline
-            import rlcompleter
-        except ImportError:
-            # Windows doesn't have readline, so gracefully ignore.
-            print("No gnureadline found")
-            pass
-        else:
-            # Mac OS X readline compatibility from http://stackoverflow.com/a/7116997
-            if "libedit" in str(readline.__doc__):
-                readline.parse_and_bind("bind ^I rl_complete")
-            else:
-                readline.parse_and_bind("tab: complete")
-            # Tab-complete names with a '-' in them
-            delims = set(readline.get_completer_delims())
-            if "-" in delims:
-                delims.remove("-")
-                readline.set_completer_delims("".join(delims))
 
         self._conf_dir = config_dir or os.path.join(
             os.environ.get("HOME", "."), ".config"

--- a/dql/history.py
+++ b/dql/history.py
@@ -1,17 +1,10 @@
 import os
 from pathlib import Path
 from typing import Optional
-from rich.pretty import pprint
 
-try:
-    import gnureadline as readline
-except Exception as e:
-    # Windows doesn't have readline, so gracefully ignore.
-    print("No gnureadline found")
-    print(e)
-else:
-    pprint(readline.__doc__)
-    pprint(dir(readline))
+from . import readline_compat
+
+readline = readline_compat.readline
 
 
 class HistoryManager(object):
@@ -35,15 +28,13 @@ class HistoryManager(object):
         actual_history_dir = history_dir or default_history_dir
         os.makedirs(actual_history_dir, exist_ok=True)
         history_file = os.path.join(actual_history_dir, self.history_file_name)
-        pprint(history_file)
         self._create_file_if_not_exists(history_file)
         return history_file
 
     def try_to_load_history(self, history_dir: Optional[str] = None) -> None:
         history_file = self._prep_history_file(history_dir)
 
-        if not readline:
-            print("No readline found, skipping history load")
+        if readline is None:
             return
 
         try:
@@ -52,57 +43,35 @@ class HistoryManager(object):
         except Exception as e:
             print(f"Error reading history file: {e}")
             self._initial_history_length = 0
-            raise e
 
     def try_to_write_history(self, history_dir: Optional[str] = None) -> None:
         history_file = self._prep_history_file(history_dir)
 
-        if not readline:
-            print("No readline found, skipping history write")
+        if readline is None:
             return
 
-        try:
-            current_history_length = readline.get_current_history_length()
-            new_history_length = current_history_length - self._initial_history_length
-            pprint(
-                {
-                    "current_history_length": current_history_length,
-                    "initial_history_length": self._initial_history_length,
-                    "new_history_length": new_history_length,
-                }
+        current_history_length = readline.get_current_history_length()
+        new_history_length = current_history_length - self._initial_history_length
+        if new_history_length < 0:
+            raise RuntimeError(
+                f"Unable to write new history. Length is less than 0. ({current_history_length} - {self._initial_history_length})"
             )
-            if new_history_length < 0:
-                raise RuntimeError(
-                    f"Unable to write new history. Length is less than 0. ({current_history_length} - {self._initial_history_length})"
-                )
-            else:
-                # append will fail if the file does not exist.
-                readline.append_history_file(new_history_length, history_file)
-        except Exception as e:
-            print(f"Error writing history to file: {e}")
-            raise e
+
+        # append will fail if the file does not exist.
+        readline.append_history_file(new_history_length, history_file)
 
     def remove_items(self, n=1):
         """Remove items from current session's in-memory history."""
-        if n <= 0:
+        if n <= 0 or readline is None:
             return
 
-        if not readline:
-            print("No readline found, skipping history remove")
-            return
-
-        try:
-            current_history_length = readline.get_current_history_length()
-            if current_history_length - n >= self._initial_history_length:
-                for _ in range(n):
-                    # pop n items from history list
-                    readline.remove_history_item(
-                        readline.get_current_history_length() - 1
-                    )
-            else:
-                raise RuntimeError(
-                    f"Requested history item removal is not in current session history range. "
-                    f"({self._initial_history_length}, {current_history_length})"
-                )
-        except Exception as e:
-            print(e)
+        current_history_length = readline.get_current_history_length()
+        if current_history_length - n >= self._initial_history_length:
+            for _ in range(n):
+                # pop n items from history list
+                readline.remove_history_item(readline.get_current_history_length() - 1)
+        else:
+            raise RuntimeError(
+                f"Requested history item removal is not in current session history range. "
+                f"({self._initial_history_length}, {current_history_length})"
+            )

--- a/dql/readline_compat.py
+++ b/dql/readline_compat.py
@@ -1,0 +1,42 @@
+"""Configure readline for cross-platform REPL support.
+
+cmd.Cmd imports the stdlib ``readline`` module at runtime.  We prefer
+``gnureadline`` for consistent behavior across Python builds, so we register
+it as ``readline`` in ``sys.modules`` before anything else imports readline.
+"""
+import sys
+from typing import Any, Optional
+
+readline: Optional[Any] = None
+
+try:
+    import gnureadline
+
+    sys.modules["readline"] = gnureadline
+    readline = gnureadline
+except ImportError:
+    try:
+        import readline as _stdlib_readline
+
+        readline = _stdlib_readline
+    except ImportError:
+        pass
+
+if readline is not None:
+    try:
+        import rlcompleter  # noqa: F401  # registers the Completer class
+
+        # Mac OS X readline compatibility from http://stackoverflow.com/a/7116997
+        if "libedit" in str(readline.__doc__):
+            readline.parse_and_bind("bind ^I rl_complete")
+        else:
+            readline.parse_and_bind("tab: complete")
+
+        # Tab-complete names with a '-' in them
+        delims = set(readline.get_completer_delims())
+        if "-" in delims:
+            delims.remove("-")
+            readline.set_completer_delims("".join(delims))
+    except Exception:
+        # Non-interactive terminals may not support readline configuration.
+        pass

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -4,7 +4,9 @@ import tempfile
 from pathlib import Path
 from unittest import TestCase
 
-import gnureadline as readline
+from dql import readline_compat
+
+readline = readline_compat.readline
 
 from dql.history import HistoryManager
 
@@ -23,7 +25,8 @@ class TestHistoryManager(TestCase):
         super().setUp()
         self._histDir = tempfile.mkdtemp()
         self._histFile = os.path.join(self._histDir, HistoryManager.history_file_name)
-        readline.clear_history()
+        if readline is not None:
+            readline.clear_history()
 
     def tearDown(self):
         super().tearDown()

--- a/tests/test_readline_compat.py
+++ b/tests/test_readline_compat.py
@@ -1,0 +1,23 @@
+import sys
+from unittest import TestCase
+
+from dql import readline_compat
+
+
+class TestReadlineCompat(TestCase):
+    def test_gnureadline_is_registered_as_readline(self):
+        if readline_compat.readline is None:
+            self.skipTest("readline is not available")
+
+        self.assertIs(sys.modules["readline"], readline_compat.readline)
+
+    def test_cmd_and_history_share_readline_buffer(self):
+        if readline_compat.readline is None:
+            self.skipTest("readline is not available")
+
+        import readline
+
+        readline.clear_history()
+        readline.add_history("shared history entry")
+        self.assertEqual(readline.get_current_history_length(), 1)
+        self.assertIs(readline, readline_compat.readline)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After migrating to `gnureadline`, readline behavior was inconsistent in some environments:

- **History not persisting** — commands entered in the REPL were not written to `~/.dql/history` on exit
- **History removal failing** — `clear`/`exit` commands could not remove items from the in-memory buffer
- **Negative history length errors** — `new_history_length < 0` when writing history

## Root cause

`cmd.Cmd` imports the **stdlib** `readline` module at runtime inside `cmdloop()`, while `HistoryManager` was importing `gnureadline` as a separate module. These are two different in-memory history buffers, so history operations in the REPL and history persistence were out of sync.

## Fix

- Add `dql/readline_compat.py` that registers `gnureadline` as `sys.modules['readline']` before anything else imports readline
- Centralize tab-completion setup (libedit vs GNU readline, `-` delimiter handling) in that module
- Clean up WIP debug code from `history.py` (`pprint`, broken `if not readline` checks, `NameError` on import failure)
- Import `readline_compat` early from `cli.py` so `cmd.Cmd` and `HistoryManager` share the same buffer
- Add regression tests in `tests/test_readline_compat.py`

## Testing

- Manual integration test verifying shared history buffer between `cmd.Cmd` and `HistoryManager` (write, append, shared buffer)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2308ebc3-dd0f-467d-8147-f81d2be32518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2308ebc3-dd0f-467d-8147-f81d2be32518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

