### PR TITLE
Set up Cursor Cloud dev environment for dql

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`dql` is a single Python CLI (the DynamoDB Query Language REPL). Dependency
+management is `uv` + project tasks via `taskipy`. Standard dev commands live in
+`doc/topics/develop.rst` and `pyproject.toml` (`[tool.taskipy.tasks]`); prefer
+those instead of duplicating commands here.
+
+The startup update script already installs `uv` (via `pip`, because the
+`astral.sh` installer is network-blocked in this environment) and runs
+`uv sync --dev`. `uv` is available on `PATH` (`~/.local/bin`) and also as
+`python3 -m uv`.
+
+Non-obvious caveats:
+
+- Run the test suite with `TTY_COMPATIBLE=0`, e.g. `TTY_COMPATIBLE=0 uv run task test`.
+  The VM's interactive shell exports `TERM=dumb`, which makes `rich` ignore the
+  console width that the tests force (200) and render at width 80 with color
+  codes, breaking the snapshot tests (`test_help_docs`, `test_ls`).
+  `TTY_COMPATIBLE=0` makes `rich` treat output as non-interactive, matching CI.
+- Tests require **DynamoDB Local** on port 8000 plus a Java runtime (Java is
+  preinstalled). Start it before running tests:
+  `./scripts/install_dynamodb_local.sh background` (downloads the jar into
+  `.dynamo-local/` on first run, then reuses it). It is a background service, so
+  it is intentionally not part of the update script.
+- Running the app against DynamoDB Local: `uv run dql -H localhost -p 8000 -c "<query>"`.
+  The client needs (dummy) AWS credentials, e.g. `AWS_ACCESS_KEY_ID=dummy
+  AWS_SECRET_ACCESS_KEY=dummy AWS_DEFAULT_REGION=us-west-1`.
+- Lint is `uv run task lint` (mypy, isort, black, pylint). It does not need
+  DynamoDB Local.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `dql` (the DynamoDB Query Language CLI) on Cursor Cloud and documents non-obvious caveats discovered during setup.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to run lint/tests/app and the key gotchas.
- Configures the startup update script to install `uv` (via `pip`, since the `astral.sh` installer is network-blocked here) and run `uv sync --dev`.

No application code was modified.

## Environment

- Package/deps: `uv` (Python 3.9 managed by uv) + `taskipy` tasks.
- Tests need DynamoDB Local on port 8000 + Java (Java 21 preinstalled). Start with `./scripts/install_dynamodb_local.sh background`.
- Key gotcha: the VM shell exports `TERM=dumb`, which makes `rich` ignore the test-forced width (200) and break two snapshot tests. Run tests with `TTY_COMPATIBLE=0` to match CI.

## Verification

- `uv run task lint` — mypy, isort, pylint pass (black flags 2 pre-existing files on this branch).
- `TTY_COMPATIBLE=0 uv run task test` — 168 passed, 2 skipped.
- `uv run dql -H localhost -p 8000 -c "..."` — created table, inserted rows, ran SELECT/UPDATE/COUNT against DynamoDB Local.

[dql_hello_world.log](https://cursor.com/agents/bc-7ed868c6-95b3-4119-90c2-767796fd04d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdql_hello_world.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ed868c6-95b3-4119-90c2-767796fd04d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ed868c6-95b3-4119-90c2-767796fd04d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

