### PR TITLE
Fix lint formatting issue

### DIFF
--- a/dql/cli.py
+++ b/dql/cli.py
@@ -19,6 +19,7 @@ import humanize
 # isort: off
 import dql.pyparsing_compat  # noqa: F401
 from pyparsing import ParseException
+
 # isort: on
 
 # pylint: disable=redefined-builtin

--- a/dql/engine.py
+++ b/dql/engine.py
@@ -53,6 +53,7 @@ from dynamo3.types import TYPES
 # isort: off
 import dql.pyparsing_compat  # noqa: F401
 from pyparsing import ParseException
+
 # isort: on
 
 from rich.progress import (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Apply Black formatting to `dql/cli.py` and `dql/engine.py`.

### Testing
- `uv run task lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c53ac71c-13da-4ade-aae1-dd06df693794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c53ac71c-13da-4ade-aae1-dd06df693794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

